### PR TITLE
Update runtime to Gnome 44

### DIFF
--- a/com.github.theironrobin.siglo.json
+++ b/com.github.theironrobin.siglo.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.theironrobin.siglo",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "siglo",
     "finish-args" : [


### PR DESCRIPTION
GNOME 42 is deprecated.