### PR TITLE
Update runtime to GNOME 46

### DIFF
--- a/com.github.theironrobin.siglo.json
+++ b/com.github.theironrobin.siglo.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.theironrobin.siglo",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "siglo",
     "finish-args" : [


### PR DESCRIPTION
GNOME 44 is EOL.